### PR TITLE
Fix MongoDB connection

### DIFF
--- a/lib/mongodb-migrations.js
+++ b/lib/mongodb-migrations.js
@@ -33,8 +33,9 @@
       this._dbReady = new Promise.fromCallback(function(cb) {
         return mongoConnect(dbConfig, cb);
       }).then((function(_this) {
-        return function(db) {
-          return _this._db = db;
+        return function(client) {
+          _this._dbClient = client;
+          return _this._db = client.db(dbConfig.name);
         };
       })(this));
       this._collName = dbConfig.collection;
@@ -300,7 +301,7 @@
         return function() {
           var e, error;
           try {
-            _this._db.close();
+            _this._dbClient.close();
             return typeof cb === "function" ? cb(null) : void 0;
           } catch (error) {
             e = error;


### PR DESCRIPTION
Upgrading to version 3.x from 2.x changes the way to get the database
object. The "connect()" method returns a MongoDB client instead of the
previously returned database.

Closing the connection is also now done on the client object.